### PR TITLE
Error in Acount Journal write mehtod

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -549,7 +549,7 @@ class AccountJournal(models.Model):
                     if bank_account.partner_id != company.partner_id:
                         raise UserError(_("The partners of the journal's company and the related bank account mismatch."))
             if 'restrict_mode_hash_table' in vals and not vals.get('restrict_mode_hash_table'):
-                journal_entry = self.env['account.move'].sudo().search([('journal_id', '=', self.id), ('state', '=', 'posted'), ('secure_sequence_number', '!=', 0)], limit=1)
+                journal_entry = self.env['account.move'].sudo().search([('journal_id', '=', journal.id), ('state', '=', 'posted'), ('secure_sequence_number', '!=', 0)], limit=1)
                 if journal_entry:
                     field_string = self._fields['restrict_mode_hash_table'].get_description(self.env)['string']
                     raise UserError(_("You cannot modify the field %s of a journal that already has accounting entries.", field_string))


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Account Journal write method is refering to self.id inside a for loop

Current behavior before PR:
Write method will not work correctly when self is a recordset with more that one record

Desired behavior after PR is merged:
Write will work correctly when self is a recordset with more that one record


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
